### PR TITLE
improved JWT Detection

### DIFF
--- a/src/app/helpers/TokenCheck.java
+++ b/src/app/helpers/TokenCheck.java
@@ -7,9 +7,25 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 
 public class TokenCheck {
 	public static boolean isValidJWT(String jwt) {
+		 
 		if (StringUtils.countMatches(jwt, ".") != 2) {
 			return false;
 		}
+		jwt=jwt.trim();
+		if(StringUtils.contains(jwt," ")){
+			return false;
+		}
+
+		String[] sArray=StringUtils.split(jwt,".");
+		if(sArray.length < 3){
+			return false;
+		}
+		for(String value:sArray){
+			if(!value.matches("[A-Za-z0-9+/=_-]+")){
+				return false;
+			}
+		}
+
 		try {
 			DecodedJWT decoded = JWT.decode(jwt);
 			decoded.getAlgorithm();

--- a/src/app/tokenposition/Body.java
+++ b/src/app/tokenposition/Body.java
@@ -1,0 +1,133 @@
+package app.tokenposition;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import org.apache.commons.lang.StringUtils;
+
+import app.helpers.ConsoleOut;
+import app.helpers.KeyValuePair;
+import app.helpers.TokenCheck;
+
+public class Body extends ITokenPosition {
+	private String token;
+	private boolean found = false;
+	private String body;
+
+	public Body(List<String> headersP, String bodyP) {
+		body = bodyP;
+	}
+
+	@Override
+	public boolean positionFound() {
+		KeyValuePair postJWT = getJWTFromBody();
+		if (postJWT != null) {
+			found = true;
+			token = postJWT.getValue();
+			return true;
+		}
+		return false;
+	}
+
+	public KeyValuePair getJWTFromBody() {
+		KeyValuePair ret;
+		if ((ret = getJWTFromBodyWithParameters()) != null) {
+			return ret;
+		} else if ((ret = getJWTFromBodyWithJson()) != null) {
+			return ret;
+		} else {
+			return getJWTFromBodyWithoutParametersOrJSON();
+		}
+	}
+
+	private KeyValuePair getJWTFromBodyWithoutParametersOrJSON() {
+		String split[] = StringUtils.split(body);
+		for (String strg : split) {
+			if (TokenCheck.isValidJWT(strg)) {
+				return new KeyValuePair("", strg);
+			}
+		}
+		return null;
+	}
+ 
+	private KeyValuePair getJWTFromBodyWithJson() {
+		JsonObject obj;
+		try {
+			obj = Json.parse(body).asObject();
+		} catch (Exception e) {
+			ConsoleOut.output("Can't parse claims - " + e.getMessage());
+			return null;
+		}
+		return lookForJwtInJsonObject(obj);
+	}
+
+	private KeyValuePair lookForJwtInJsonObject(JsonObject object) {
+		KeyValuePair rec;
+		for (String name : object.names()) {
+			if (object.get(name).isString()) {
+				if (TokenCheck.isValidJWT(object.get(name).asString())) {
+					return new KeyValuePair(name, object.get(name).asString().trim());
+				}
+			} else if (object.get(name).isObject()) {
+				if ((rec = lookForJwtInJsonObject(object.get(name).asObject())) != null) {
+					return rec;
+				}
+			}
+		}
+		return null;
+	}
+
+
+	private KeyValuePair getJWTFromBodyWithParameters() {
+
+		int from = 0;
+		int index = body.indexOf("&") == -1 ? body.length() : body.indexOf("&");
+		int parameterCount = StringUtils.countMatches(body, "&") + 1;
+
+		for (int i = 0; i < parameterCount; i++) {
+			String parameter = body.substring(from, index);
+			parameter = parameter.replace("&", "");
+
+			String[] parameterSplit = parameter.split(Pattern.quote("="));
+			if (parameterSplit.length > 1) {
+				String name = parameterSplit[0];
+				String value = parameterSplit[1];
+				if (TokenCheck.isValidJWT(value)) {
+					return new KeyValuePair(name, value);
+				}
+
+				from = index;
+				index = body.indexOf("&", index + 1);
+				if (index == -1) {
+					index = body.length();
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String getToken() {
+		return found ? token : "";
+	}
+
+	@Override
+	public byte[] replaceToken(String newToken) {
+		body = replaceTokenImpl(newToken, body);
+		return getHelpers().buildHttpMessage(getHeaders(), body.getBytes());
+	}
+
+	public String replaceTokenImpl(String newToken, String body) {
+		boolean replaced = false;
+		KeyValuePair postJWT = getJWTFromBody();
+		if (postJWT != null) {
+			body = body.replace(postJWT.getValue(), newToken);
+		}
+		if (!replaced) {
+			ConsoleOut.output("Could not replace token in post body.");
+		}
+		return body;
+	}
+
+}

--- a/src/app/tokenposition/ITokenPosition.java
+++ b/src/app/tokenposition/ITokenPosition.java
@@ -47,7 +47,7 @@ public abstract class ITokenPosition {
 	}
 
 	public static ITokenPosition findTokenPositionImplementation(byte[] content, boolean isRequest, IExtensionHelpers helpers) {
-		List<Class<? extends ITokenPosition>> implementations = Arrays.asList(AuthorizationBearerHeader.class, PostBody.class, Cookie.class);
+		List<Class<? extends ITokenPosition>> implementations = Arrays.asList(AuthorizationBearerHeader.class, PostBody.class, Cookie.class,Body.class);
 		for (Class<? extends ITokenPosition> implClass : implementations) {
 			try {
 				List<String> headers;

--- a/test/app/TestBodyDetection.java
+++ b/test/app/TestBodyDetection.java
@@ -1,0 +1,150 @@
+package app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import app.helpers.KeyValuePair;
+import app.tokenposition.Body;
+
+public class TestBodyDetection {
+	
+	@Test
+	public void testBodyWithParam() {
+		String body = "test=best&abc="+TestTokens.hs256_token;
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	
+	@Test
+	public void testBodyWithoutParam() {
+		String body = "a "+TestTokens.hs256_token+ " b";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	
+	
+	@Test
+	public void testBodyWithSimpleJSON() {
+		String body = "{\"aaaa\":\""+TestTokens.hs256_token+ "\"}";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+
+	@Test
+	public void testBodyWithComplexJSON() {
+		String body = "{ \"bbbb\" : { \" cccc \": { \" dddd\":\""+TestTokens.hs256_token+ " \"}}}";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertNotEquals(result,null);
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	
+	@Test
+	public void testBodyWithFaultyJSON() {
+		String body = "{ \"bbbb\" : { \" cccc \": { \" dddd\":"+TestTokens.hs256_token+ " \"}}}";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(result,null);	
+	}
+	@Test
+	public void testBodyWithEmptyJSON() {
+		String body = "{}";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(result,null);	
+	}
+
+	@Test
+	public void testBodyWithParamAlone() {
+		String body = "token="+TestTokens.hs256_token;
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	
+	@Test
+	public void testBodyWithoutParamAlone() {
+		String body = TestTokens.hs256_token;
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	@Test
+	public void testBodyReversed() {
+		String body = "egg="+TestTokens.hs256_token+"&test=best";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(TestTokens.hs256_token,result.getValue());	
+	}
+	@Test
+	public void testBodyInvalidWithParam() {
+		String body = "yo="+TestTokens.invalid_token+"&test=best";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(null,result);	
+	}
+
+	@Test
+	public void testBodyInvalidWithoutParam() {
+		String body = "ab "+TestTokens.invalid_token+" de";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(null,result);	
+	}
+	@Test
+	public void testPostBodyInvalid2() {
+		String body = TestTokens.hs256_token+"&";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(null,result);	
+	}
+
+
+	@Test
+	public void testPostBodyWithoutParamsValid() {
+		String body = TestTokens.hs256_token;
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(result.getValue(),TestTokens.hs256_token);	
+	}
+
+	@Test
+	public void testPostBodyNone() {
+		String body = "";
+		Body pb = new Body(null,body);
+		KeyValuePair result = pb.getJWTFromBody();
+		assertEquals(null,result);	
+	}
+	
+	@Test
+	public void testPostBodyReplaceWithParam() {
+		String body = "test=best&token="+TestTokens.hs256_token;
+		Body pb = new Body(null,body);
+		@SuppressWarnings("unused")
+		KeyValuePair result = pb.getJWTFromBody();
+		pb.getToken();
+		String replaced = pb.replaceTokenImpl(TestTokens.hs256_token_2,body);
+		Body pbR = new Body(null,replaced);
+		KeyValuePair resultR = pbR.getJWTFromBody();
+		assertEquals(resultR.getValue(),TestTokens.hs256_token_2);	
+	}
+	
+
+	@Test
+	public void testPostBodyReplaceWithoutParam() {
+		String body = "ab\n cd "+TestTokens.hs256_token+ " cd";
+		Body pb = new Body(null,body);
+		@SuppressWarnings("unused")
+		KeyValuePair result = pb.getJWTFromBody();
+		pb.getToken();
+		String replaced = pb.replaceTokenImpl(TestTokens.hs256_token_2,body);
+		Body pbR = new Body(null,replaced);
+		KeyValuePair resultR = pbR.getJWTFromBody();
+		assertEquals(resultR.getValue(),TestTokens.hs256_token_2);	
+	}
+}


### PR DESCRIPTION
Added recognition of JWT in Body when:
1. in JSON format (e.g {"a":"......", "b":"J.W.T",..}, recognition also in nested JSON
2. in Parameter format without keywords (e.g. a=bc&d=J.W.T)
3. plain JWT. (e.g. ab cd ef J.W.T hi )

PS: Thx for this very good extension, very useful for audits. Any feedback on the modifications are welcome. In particular if you accept the merge, please write my company name somewhere (Brainloop) as I did this on my working hours :)

Cheers,
Antoine