### PR TITLE
traffic light to differentiate between wrong key and wrong claims

### DIFF
--- a/src/app/controllers/JWTSuiteTabController.java
+++ b/src/app/controllers/JWTSuiteTabController.java
@@ -11,7 +11,9 @@ import javax.swing.event.DocumentListener;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import app.algorithm.AlgorithmLinker;
@@ -119,8 +121,18 @@ public class JWTSuiteTabController extends Observable implements ITab {
 		} catch (JWTVerificationException e) {
 			ConsoleOut.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setVerificationResult(e.getMessage());
-			jwtSTM.setJwtSignatureColor(Settings.colorInvalid);
-			jwtSTM.setVerificationLabel(Strings.verificationWrongKey);
+
+			if (e instanceof SignatureVerificationException) {
+				jwtSTM.setJwtSignatureColor(Settings.colorInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationInvalidSignature);
+			} else if(e instanceof InvalidClaimException) {
+				jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationInvalidClaim);
+			}else {
+				jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationError);
+			}
+
 		} catch (IllegalArgumentException | UnsupportedEncodingException e) {
 			ConsoleOut.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);

--- a/src/app/helpers/Strings.java
+++ b/src/app/helpers/Strings.java
@@ -18,8 +18,10 @@ public class Strings {
 	public static final String enterJWT = "Enter JWT";
 	
 	public static final String verificationValid = "Signature verified";
-	public static final String verificationInvalidKey = "Invalid key";
-	public static final String verificationWrongKey = "Invalid Signature / wrong key / claim failed";
+	public static final String verificationInvalidKey = "Invalid Key";
+	public static String verificationInvalidSignature = "Cannot verify Signature";
+	public static String verificationInvalidClaim = "Not all Claims accepted";
+	public static final String verificationError = "Invalid Signature / wrong key / claim failed";
 
 	public static final String interceptRecalculationKey = "Secret / Key for Signature recalculation:";
 
@@ -76,7 +78,7 @@ public class Strings {
 									+"YqWZhkyQ8C05tDyGvDI5b7bVmD1pxmnhG9sOktrkDVkOsYUnAhRwCgmuExkoeGWP"
 									+"vUt+85cmMpJfHHqbrb5FLqTeXQ==";
 
-	
+
 	public static String filePathToString(String filePath) {
 		StringBuilder contentBuilder = new StringBuilder();
 		try (BufferedReader br = new BufferedReader(new FileReader(filePath))) {


### PR DESCRIPTION
Code for a traffic light was already there. I just looked into JWTSuiteTabController line 116.
verifier.verify has this lines:
`this.verifyAlgorithm(jwt, this.algorithm);`
`this.verifySignature(TokenUtils.splitToken(token));`
`this.verifyClaims(jwt, this.claims);`
Each of them have a subclass Expection of JWTVerificationException we can check against:
`SignatureVerificationException `
`AlgorithmMismatchException`
`InvalidClaimException`
I only inserted Code to check Signature and Claims, since im unsure if an AlgorithmMismatch could accure in the way the code is used.
Also i didn't touch the Code in the previous inserted catch
`(IllegalArgumentException | UnsupportedEncodingException e)`
because i don't know about its purposes or edge cases.
