### PR TITLE
added more values to jwtKeywords

### DIFF
--- a/src/app/tokenposition/AuthorizationBearerHeader.java
+++ b/src/app/tokenposition/AuthorizationBearerHeader.java
@@ -7,7 +7,7 @@ import app.helpers.CustomJWToken;
 
 public class AuthorizationBearerHeader extends ITokenPosition {
 
-	private static List<String> jwtKeywords = Arrays.asList("Authorization: Bearer");
+	private static List<String> jwtKeywords = Arrays.asList("Authorization: Bearer", "Authorization: bearer", "authorization: Bearer", "authorization: bearer");
 	private String selectedKeyword;
 	private Integer headerIndex;
 	private List<String> headers;


### PR DESCRIPTION
I've noticed in some of my testing that some web servers will respond with lower case for authorization and bearer verbs. This change should cover both scenarios. Ideally we'd ignore case completely but my Java isn't up to scratch :)

Have compiled in Eclipse and tested as per the instructions in the README.