### PR TITLE
Support for GZipped JWT

### DIFF
--- a/src/app/controllers/HighLightController.java
+++ b/src/app/controllers/HighLightController.java
@@ -1,7 +1,6 @@
 package app.controllers;
 
 import app.helpers.Config;
-import app.helpers.Output;
 import app.tokenposition.ITokenPosition;
 import burp.IBurpExtenderCallbacks;
 import burp.IExtensionHelpers;

--- a/src/app/controllers/HighLightController.java
+++ b/src/app/controllers/HighLightController.java
@@ -1,6 +1,7 @@
 package app.controllers;
 
 import app.helpers.Config;
+import app.helpers.Output;
 import app.tokenposition.ITokenPosition;
 import burp.IBurpExtenderCallbacks;
 import burp.IExtensionHelpers;

--- a/src/app/controllers/JWTSuiteTabController.java
+++ b/src/app/controllers/JWTSuiteTabController.java
@@ -91,7 +91,6 @@ public class JWTSuiteTabController implements ITab {
 			jwtSTM.setVerificationLabel(Strings.verificationValid);
 			test.getAlgorithm();
 		} catch (JWTVerificationException e) {
-			Output.output(e.getClass().getTypeName());
 			Output.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setVerificationResult(e.getMessage());
 

--- a/src/app/controllers/JWTSuiteTabController.java
+++ b/src/app/controllers/JWTSuiteTabController.java
@@ -83,13 +83,15 @@ public class JWTSuiteTabController implements ITab {
 		jwtSTM.setJwtKey(key);
 		jwtSTM.setVerificationResult("");
 		try {
-			String curAlgo = new CustomJWToken(jwtSTM.getJwtInput()).getAlgorithm();
+			CustomJWToken token = new CustomJWToken(jwtSTM.getJwtInput());
+			String curAlgo = token.getAlgorithm();
 			JWTVerifier verifier = JWT.require(AlgorithmLinker.getVerifierAlgorithm(curAlgo, key)).build();
-			DecodedJWT test = verifier.verify(jwtSTM.getJwtInput());
+			DecodedJWT test = verifier.verify(token.getToken());
 			jwtSTM.setJwtSignatureColor(Settings.colorValid);
 			jwtSTM.setVerificationLabel(Strings.verificationValid);
 			test.getAlgorithm();
 		} catch (JWTVerificationException e) {
+			Output.output(e.getClass().getTypeName());
 			Output.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setVerificationResult(e.getMessage());
 

--- a/src/model/CustomJWToken.java
+++ b/src/model/CustomJWToken.java
@@ -1,6 +1,8 @@
 package model;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
@@ -8,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;

--- a/src/model/CustomJWToken.java
+++ b/src/model/CustomJWToken.java
@@ -1,12 +1,14 @@
 package model;
 
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
@@ -42,8 +44,29 @@ public class CustomJWToken extends JWT {
 			final String[] parts = splitToken(token);
 			try {
 				headerJson = StringUtils.newStringUtf8(Base64.decodeBase64(parts[0]));
-				payloadJson = StringUtils.newStringUtf8(Base64.decodeBase64(parts[1]));
+				byte[] payloadBase64 = Base64.decodeBase64(parts[1]);
+				payloadJson = StringUtils.newStringUtf8(payloadBase64);
+
+				JsonObject headerObject;
+				try {
+					headerObject = Json.parse(headerJson).asObject();
+					if (headerObject.getString("zip", "").equalsIgnoreCase("GZIP")) {
+						GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(payloadBase64));
+						ByteArrayOutputStream buf = new ByteArrayOutputStream();
+						for (int result = gis.read(); result != -1; result = gis.read()) {
+							buf.write((byte) result);
+						}
+						payloadJson = buf.toString("UTF-8");
+					}
+				} catch (IOException e) {
+					Output.output("Could not gunzip JSON - " + e.getMessage());
+				} catch (Exception e) {
+					Output.output("Could not parse header - " + e.getMessage());
+					return;
+				}
+
 				checkRegisteredClaims(payloadJson);
+
 			} catch (NullPointerException e) {
 				Output.outputError("The UTF-8 Charset isn't initialized (" + e.getMessage() + ")");
 			}
@@ -178,7 +201,11 @@ public class CustomJWToken extends JWT {
 			return false;
 		}
 		try {
-			JWT.decode(token);
+			String tok = new CustomJWToken(token).getToken();
+			if (tok == null) {
+				return false;
+			}
+			JWT.decode(tok);
 			return true;
 		} catch (JWTDecodeException exception) {
 		}


### PR DESCRIPTION
Adds support for decoding JWT with GZipped bodies. It doesn't re-zip them though, so this would probably fail when modifying the JWT, unless the `"zip": "GZIP"` header is manually removed.