### PR TITLE
Interceptor Tab UI Redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ lib/
 
 # Intellij
 .idea/
+
+# Burp Interfaces
+src/burp
+!src/burp/BurpExtender.java

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ lib/
 
 # ignore debug output
 *log
+
+# Intellij
+.idea/

--- a/src/app/algorithm/AlgorithmLinker.java
+++ b/src/app/algorithm/AlgorithmLinker.java
@@ -15,6 +15,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.EncodedKeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.RandomStringUtils;
@@ -33,6 +34,12 @@ public class AlgorithmLinker {
 	
 	public static final app.algorithm.AlgorithmWrapper none = 
 			new app.algorithm.AlgorithmWrapper("none",AlgorithmType.none);
+	public static final app.algorithm.AlgorithmWrapper None =
+			new app.algorithm.AlgorithmWrapper("None",AlgorithmType.none);
+	public static final app.algorithm.AlgorithmWrapper nOnE =
+			new app.algorithm.AlgorithmWrapper("nOnE",AlgorithmType.none);
+	public static final app.algorithm.AlgorithmWrapper NONE =
+			new app.algorithm.AlgorithmWrapper("NONE",AlgorithmType.none);
 	public static final app.algorithm.AlgorithmWrapper HS256 = 
 			new app.algorithm.AlgorithmWrapper("HS256",AlgorithmType.symmetric);
 	public static final app.algorithm.AlgorithmWrapper HS384 =
@@ -54,8 +61,13 @@ public class AlgorithmLinker {
 	public static final app.algorithm.AlgorithmWrapper ES512 = 
 			new app.algorithm.AlgorithmWrapper("ES512",AlgorithmType.asymmetric);
 
-	private static final app.algorithm.AlgorithmWrapper[] supportedAlgorithms = { 
-			none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES256K, ES384, ES512 };
+	public static final app.algorithm.AlgorithmWrapper[] supportedAlgorithms = {
+			none, None, nOnE, NONE, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES256K, ES384, ES512
+	};
+
+	public static final app.algorithm.AlgorithmWrapper[] noneAlgorithms = {
+			none, None, nOnE, NONE
+	};
 
 	private static PublicKey generatePublicKeyFromString(String key, String algorithm) {
 		PublicKey publicKey = null;
@@ -236,5 +248,9 @@ public class AlgorithmLinker {
 
 	public static app.algorithm.AlgorithmWrapper[] getSupportedAlgorithms() {
 		return supportedAlgorithms;
+	}
+
+	public static boolean isNoneAlgorithm(String algorithm) {
+		return Arrays.stream(noneAlgorithms).anyMatch(aw -> aw.getAlgorithm().equals(algorithm));
 	}
 }

--- a/src/app/controllers/JWTInterceptTabController.java
+++ b/src/app/controllers/JWTInterceptTabController.java
@@ -17,7 +17,10 @@ import java.util.List;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
+import app.helpers.DelayedDocumentListener;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
@@ -47,14 +50,7 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 	private IExtensionHelpers helpers;
 	private byte[] message;
 	private ITokenPosition tokenPosition;
-	private boolean dontModify;
-	private boolean randomKey;
-	private boolean keepOriginalSignature;
-	private boolean chooseSignature;
-	private boolean recalculateSignature;
-	private String algAttackMode;
-	private boolean cveAttackMode;
-	private boolean edited;
+	private boolean isModified;
 
 	public JWTInterceptTabController(IBurpExtenderCallbacks callbacks, JWTInterceptModel jwIM, JWTInterceptTab jwtST) {
 		this.jwtIM = jwIM;
@@ -64,78 +60,42 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 		createAndRegisterActionListeners(jwtST);
 	}
 
-	private void cveAttackChanged() {
-		JCheckBox jcb = jwtST.getCVEAttackCheckBox();
-		cveAttackMode = jcb.isSelected();
-		jwtST.getNoneAttackComboBox().setEnabled(!cveAttackMode);
-		jwtST.getRdbtnDontModify().setEnabled(!cveAttackMode);
-		jwtST.getRdbtnOriginalSignature().setEnabled(!cveAttackMode);
-		jwtST.getRdbtnRandomKey().setEnabled(!cveAttackMode);
-		jwtST.getRdbtnRecalculateSignature().setEnabled(!cveAttackMode);
-		jwtST.setKeyFieldState(!cveAttackMode);
-		jwtST.getCVECopyBtn().setVisible(cveAttackMode);
-		if (cveAttackMode) {
-			jwtST.getRdbtnDontModify().setSelected(true);
-			jwtST.getRdbtnOriginalSignature().setSelected(false);
-			jwtST.getRdbtnRandomKey().setSelected(false);
-			jwtST.getRdbtnRecalculateSignature().setSelected(false);
-		} else {
-			jwtST.setKeyFieldValue("");
-			jwtST.setKeyFieldState(false);
+
+	// Callback for Algorithm ComboBox - changes algorithm and updates view
+	private void changeAlgorithm() {
+		Output.output("changeAlgorithm()");
+		isModified = true;
+
+		String algorithm = (String)jwtST.getAlgorithmComboBox().getSelectedItem();
+		CustomJWToken token = null;
+		try {
+			token = ReadableTokenFormat.getTokenFromReadableFormat(jwtIM.getJWTJSON());
+			String header = token.getHeaderJson();
+			token.setHeaderJson(header.replace(token.getAlgorithm(), algorithm));
+			// TODO: always remove signature if none algo?
+//			if(AlgorithmLinker.isNoneAlgorithm(algorithm)){
+//				token.setSignature("");
+//			}
+
+			jwtIM.setJWTJSON(ReadableTokenFormat.getReadableFormat(token));
+			jwtIM.setSignature(token.getSignature());
+			jwtST.updateSetView(false);
+		} catch (InvalidTokenFormat e) {
+			e.printStackTrace();
+			Output.outputError("Exception: " + e.getMessage());
 		}
 	}
 
-	private void algAttackChanged() {
-		JComboBox<String> jCB = jwtST.getNoneAttackComboBox();
-		switch (jCB.getSelectedIndex()) {
-		default:
-		case 0:
-			algAttackMode = null;
-			break;
-		case 1:
-			algAttackMode = "none";
-			break;
-		case 2:
-			algAttackMode = "None";
-			break;
-		case 3:
-			algAttackMode = "nOnE";
-			break;
-		case 4:
-			algAttackMode = "NONE";
-			break;
-		}
-	}
-
-	private void radioButtonChanged(boolean cDM, boolean cRK, boolean cOS, boolean cRS, boolean cCS) {
-		boolean oldRandomKey = randomKey;
-
-		dontModify = jwtST.getRdbtnDontModify().isSelected();
-		randomKey = jwtST.getRdbtnRandomKey().isSelected();
-		keepOriginalSignature = jwtST.getRdbtnOriginalSignature().isSelected();
-		recalculateSignature = jwtST.getRdbtnRecalculateSignature().isSelected();
-		chooseSignature = jwtST.getRdbtnChooseSignature().isSelected();
-
-		jwtST.setKeyFieldState(!keepOriginalSignature && !dontModify && !randomKey && !chooseSignature);
-
-		if (keepOriginalSignature || dontModify) {
-			jwtIM.setJWTKey("");
-			jwtST.setKeyFieldValue("");
-		}
-		if (randomKey && !oldRandomKey) {
-			generateRandomKey();
-		}
-		if (cCS) {
-			FileDialog dialog = new FileDialog((Frame) null, "Select File to Open");
-			dialog.setMode(FileDialog.LOAD);
-			dialog.setVisible(true);
-			if(dialog.getFile()!=null) {
-				String file = dialog.getDirectory() + dialog.getFile();
-				Output.output(file + " chosen.");
-				String chosen = Strings.filePathToString(file);
-				jwtIM.setJWTKey(chosen);
-				jwtST.updateSetView(false);	
-			}
+	private void loadKeyFile() {
+		FileDialog dialog = new FileDialog((Frame) null, "Select file to open");
+		dialog.setMode(FileDialog.LOAD);
+		dialog.setVisible(true);
+		if(dialog.getFile()!=null) {
+			String file = dialog.getDirectory() + dialog.getFile();
+			Output.output(file + " chosen.");
+			String chosen = Strings.filePathToString(file);
+			jwtIM.setJWTKey(chosen);
+			jwtST.updateSetView(false);
 		}
 	}
 
@@ -161,12 +121,23 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 				CustomJWToken token = null;
 				try {
 					token = ReadableTokenFormat.getTokenFromReadableFormat(jwtST.getJWTfromArea());
-					Output.output("Generating Random Key for Signature Calculation");
-					String randomKey = AlgorithmLinker.getRandomKey(token.getAlgorithm());
-					Output.output("RandomKey generated: " + randomKey);
-					jwtIM.setJWTKey(randomKey);
+					String algorithm = token.getAlgorithm();
+
+					if(AlgorithmLinker.isNoneAlgorithm(algorithm)){
+						jwtIM.setJWTKey("");
+					} else {
+						Output.output("Generating Random Key");
+						String randomKey = AlgorithmLinker.getRandomKey(algorithm);
+						Output.output("RandomKey generated: " + randomKey);
+						jwtIM.setJWTKey(randomKey);
+					}
+
+//					jwtIM.setJWTJSON(ReadableTokenFormat.getReadableFormat(token));
+//					jwtIM.setSignature(token.getSignature());
 					jwtST.updateSetView(false);
+
 				} catch (InvalidTokenFormat invalidTokenFormat) {
+					Output.outputError("InvalidTokenFormat: " + token!=null ? token.getAlgorithm() : "null");
 					invalidTokenFormat.printStackTrace();
 				}
 			}
@@ -180,94 +151,121 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 
 	@Override
 	public void setMessage(byte[] content, boolean isRequest) {
-		edited = false;
+		Output.output("setMessage()");
+		isModified = false;
 		tokenPosition = ITokenPosition.findTokenPositionImplementation(content, isRequest, helpers);
 		jwtIM.setcFW(tokenPosition.getcFW());
 		if (tokenPosition == null) {
 			jwtST.updateSetView(true);
 		} else {
-			jwtIM.setJWT(tokenPosition.getToken());
-			CustomJWToken cJWT = new CustomJWToken(jwtIM.getJWT());
+			String rawToken = tokenPosition.getToken();
+			CustomJWToken cJWT = new CustomJWToken(rawToken);
 			List<TimeClaim> tcl = cJWT.getTimeClaimList();
 			jwtIM.setTimeClaims(tcl);
 			jwtIM.setJWTJSON(ReadableTokenFormat.getReadableFormat(cJWT));
 			jwtIM.setSignature(cJWT.getSignature());
+
 			jwtST.updateSetView(Config.resetEditor);
-			algAttackMode = null;
-			if(Config.resetEditor) {
-				jwtST.getNoneAttackComboBox().setSelectedIndex(0);				
-			}
+//			if(Config.resetEditor) {
+				// TODO: disable combobox to avoid triggering handler
+//				jwtST.getAlgorithmComboBox().setSelectedIndex(0);
+//			}
 		}
 		this.message = content;
 	}
 
-	@Override
-	public byte[] getMessage() {
-		// see https://github.com/PortSwigger/example-custom-editor-tab/blob/master/java/BurpExtender.java#L119		
-		boolean changesPerformed = jwtST.jwtWasChanged();
-		if(!changesPerformed && !recalculateSignature && !randomKey && !chooseSignature && algAttackMode==null && !cveAttackMode) {
-			return this.message;
+
+	public void updateSignature() {
+		Output.output("updateSignature()");
+		isModified = true;
+
+		String algorithm;
+		try {
+			CustomJWToken token = ReadableTokenFormat.getTokenFromReadableFormat(jwtST.getJWTfromArea());
+			algorithm = token.getAlgorithm();
+
+			if(AlgorithmLinker.isNoneAlgorithm(algorithm)){
+				token.setSignature("");
+			} else {
+				String cleanKey = jwtST.getKeyFieldValue().replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "");
+				//jwtIM.setJWTKey(cleanKey);
+
+				Output.output("Recalculating Signature with Secret - '" + cleanKey + "'");
+				token.calculateAndSetSignature(AlgorithmLinker.getSignerAlgorithm(algorithm, cleanKey));
+
+				// TODO: add toggle for this?
+				//  addLogHeadersToRequest();
+			}
+
+			// TODO: any other jwtIM values to update?
+			jwtIM.setJWTJSON(ReadableTokenFormat.getReadableFormat(token));
+			jwtIM.setSignature(token.getSignature());
+			jwtST.updateSetView(false);
+		} catch (IllegalArgumentException | UnsupportedEncodingException | InvalidTokenFormat e) {
+			Output.outputError(e.getStackTrace().toString());
 		}
-		
-		jwtIM.setProblemDetail("");
-		radioButtonChanged(true, false, false, false, false);
-		jwtST.getCVEAttackCheckBox().setSelected(false);
-		CustomJWToken token = null;
+	}
+
+	private void parseAndUpdateToken() {
+		CustomJWToken token;
 		try {
 			token = ReadableTokenFormat.getTokenFromReadableFormat(jwtST.getJWTfromArea());
+			jwtIM.setJWTJSON(ReadableTokenFormat.getReadableFormat(token));
+			jwtIM.setSignature(token.getSignature());
+			jwtST.updateSetView(false);
 		} catch (InvalidTokenFormat e) {
-			jwtIM.setProblemDetail(e.getMessage());
-			return this.message;
+			e.printStackTrace();
+			Output.output("Exception: " + e.getMessage());
+			//TODO: show warning in UI
 		}
+	}
 
-		if ((recalculateSignature || randomKey || chooseSignature)) {
-			edited = true;
-			if (recalculateSignature) {
-				String cleanKey = jwtST.getKeyFieldValue().replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "");
-				jwtIM.setJWTKey(cleanKey);
-			}
-			Algorithm algo;
-			try {
-				Output.output("Recalculating Signature with Secret - '" + jwtIM.getJWTKey() + "'");
-				algo = AlgorithmLinker.getSignerAlgorithm(token.getAlgorithm(), jwtIM.getJWTKey());
-				token.calculateAndSetSignature(algo);
-				addLogHeadersToRequest();
-			} catch (IllegalArgumentException | UnsupportedEncodingException e) {
-				Output.outputError(e.getStackTrace().toString());
-			}
-		} else if (keepOriginalSignature) {
-			jwtIM.setSignature(jwtIM.getOriginalSignature());
+	private void updateKey() {
+		jwtIM.setJWTKey(jwtST.getKeyFieldValue());
+	}
+
+
+	// TODO: re-add cve Attack
+//		if (cveAttackMode) {
+//			edited = true;
+//			Output.output("CVE Attack mode");
+//			String headerJSON = token.getHeaderJson();
+//			JsonObject headerJSONObj = Json.parse(headerJSON).asObject();
+//			headerJSONObj.set("alg", "RS256");
+//			JsonObject jwk = new JsonObject();
+//			jwk.add("kty", "RSA");
+//			jwk.add("kid", "jwt4b@portswigger.net");
+//			jwk.add("use", "sig");
+//			RSAPublicKey pk = loadPublicKey();
+//			jwk.add("n", Base64.getUrlEncoder().encodeToString(pk.getPublicExponent().toByteArray()));
+//			jwk.add("e", Base64.getUrlEncoder().encodeToString(pk.getModulus().toByteArray()));
+//			headerJSONObj.add("jwk", jwk);
+//			token.setHeaderJson(headerJSONObj.toString());
+//			Algorithm algo;
+//			try {
+//				algo = AlgorithmLinker.getSignerAlgorithm(token.getAlgorithm(), Config.cveAttackModePrivateKey);
+//				token.calculateAndSetSignature(algo);
+//			} catch (UnsupportedEncodingException e) {
+//				Output.outputError("Failed to sign when using cve attack mode");
+//				e.printStackTrace();
+//			}
+//		}
+
+
+	@Override
+	public byte[] getMessage() {
+		// see https://github.com/PortSwigger/example-custom-editor-tab/blob/master/java/BurpExtender.java#L119
+
+		CustomJWToken token = null;
+		try {
+			// jwtIM.JWTJson is 'the' source of truth for our current state
+			token = ReadableTokenFormat.getTokenFromReadableFormat(jwtIM.getJWTJSON());
+		} catch (InvalidTokenFormat e) {
+			e.printStackTrace();
+			Output.outputError("Exception: [getMessage()] " + e.getMessage());
 		}
-		if (algAttackMode != null) {
-			edited = true;
-			String header = token.getHeaderJson();
-			token.setHeaderJson(header.replace(token.getAlgorithm(), algAttackMode));
-			token.setSignature("");
-		}
-		if (cveAttackMode) {
-			edited = true;
-			String headerJSON = token.getHeaderJson();
-			JsonObject headerJSONObj = Json.parse(headerJSON).asObject();
-			headerJSONObj.set("alg", "RS256");
-			JsonObject jwk = new JsonObject();
-			jwk.add("kty", "RSA");
-			jwk.add("kid", "jwt4b@portswigger.net");
-			jwk.add("use", "sig");
-			RSAPublicKey pk = loadPublicKey();
-			jwk.add("n", Base64.getUrlEncoder().encodeToString(pk.getPublicExponent().toByteArray()));
-			jwk.add("e", Base64.getUrlEncoder().encodeToString(pk.getModulus().toByteArray()));
-			headerJSONObj.add("jwk", jwk);
-			token.setHeaderJson(headerJSONObj.toString());
-			Algorithm algo;
-			try {
-				algo = AlgorithmLinker.getSignerAlgorithm(token.getAlgorithm(), Config.cveAttackModePrivateKey);
-				token.calculateAndSetSignature(algo);
-			} catch (UnsupportedEncodingException e) {
-				Output.outputError("Failed to sign when using cve attack mode");
-				e.printStackTrace();
-			}
-		}		
 		// token may be null, if it is invalid JSON, if so, don't try changing anything
+		// TODO: what to return if token failes to validate? last valid state/original message?
 		if(token.getToken()!=null) {
 			this.message = this.tokenPosition.replaceToken(token.getToken());
 		}
@@ -296,7 +294,7 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 
 	@Override
 	public boolean isModified() {
-		return edited;
+		return isModified;
 	}
 
 	@Override
@@ -305,63 +303,65 @@ public class JWTInterceptTabController implements IMessageEditorTab {
 	}
 	
 	private void createAndRegisterActionListeners(JWTInterceptTab jwtST) {
-		jwtST.getJwtArea().addKeyListener(new KeyListener() {
-			@Override
-			public void keyTyped(KeyEvent arg0) {
-			}
-			@Override
-			public void keyReleased(KeyEvent arg0) {
-			}
-			@Override
-			public void keyPressed(KeyEvent arg0) {
-				edited = true;
-			}
-		});
 
-		ActionListener dontModifyListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				radioButtonChanged(true, false, false, false, false);
-			}
-		};
 		ActionListener randomKeyListener = new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				radioButtonChanged(false, true, false, false, false);
-			}
-		};
-		ActionListener originalSignatureListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				radioButtonChanged(false, false, true, false, false);
-			}
-		};
-		ActionListener recalculateSignatureListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				radioButtonChanged(false, false, false, true, false);
-			}
-		};
-		ActionListener chooseSignatureListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				radioButtonChanged(false, false, false, false, true);
-			}
-		};
-		ActionListener algAttackListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				algAttackChanged();
-			}
-		};
-		ActionListener cveAttackListener = new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				cveAttackChanged();
+				generateRandomKey();
 			}
 		};
 
-		jwtST.registerActionListeners(dontModifyListener, randomKeyListener, originalSignatureListener,
-				recalculateSignatureListener, chooseSignatureListener, algAttackListener, cveAttackListener);
+		ActionListener updateSignatureListener = new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				updateSignature();
+			}
+		};
+
+		ActionListener changeAlgorithmListener = new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				changeAlgorithm();
+			}
+		};
+
+		DocumentListener jwtChangeListener = new DelayedDocumentListener(new DocumentListener() {
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				isModified = true;
+				parseAndUpdateToken();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				isModified = true;
+				parseAndUpdateToken();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				isModified = true;
+				parseAndUpdateToken();
+			}
+		});
+
+		DocumentListener keyChangeListener = new DelayedDocumentListener(new DocumentListener() {
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				updateKey();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				updateKey();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				updateKey();
+			}
+		});
+
+		jwtST.registerActionListeners(changeAlgorithmListener, randomKeyListener, updateSignatureListener, jwtChangeListener, keyChangeListener);
 	}
 }

--- a/src/app/helpers/DelayedDocumentListener.java
+++ b/src/app/helpers/DelayedDocumentListener.java
@@ -1,0 +1,62 @@
+package app.helpers;
+
+import javax.swing.Timer;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+// Source: https://raw.githubusercontent.com/bonifaido/JIT-Tree/master/src/main/java/me/nandork/jittree/DelayedDocumentListener.java
+// License: MIT (https://opensource.org/licenses/MIT)
+
+public class DelayedDocumentListener implements DocumentListener {
+
+    public static final int DELAY = 400;
+
+    private final Timer timer;
+    private DocumentEvent lastEvent;
+
+    public DelayedDocumentListener(DocumentListener delegate) {
+        this(delegate, DELAY);
+    }
+
+    public DelayedDocumentListener(final DocumentListener delegate, int delay) {
+        timer = new Timer(delay, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                timer.stop();
+                fireLastEventOn(delegate);
+            }
+        });
+    }
+
+    private void fireLastEventOn(DocumentListener delegate) {
+        if (lastEvent.getType() == DocumentEvent.EventType.INSERT) {
+            delegate.insertUpdate(lastEvent);
+        } else if (lastEvent.getType() == DocumentEvent.EventType.REMOVE) {
+            delegate.removeUpdate(lastEvent);
+        } else {
+            delegate.changedUpdate(lastEvent);
+        }
+    }
+
+    private void storeUpdate(DocumentEvent e) {
+        lastEvent = e;
+        timer.restart();
+    }
+
+    @Override
+    public void insertUpdate(DocumentEvent e) {
+        storeUpdate(e);
+    }
+
+    @Override
+    public void removeUpdate(DocumentEvent e) {
+        storeUpdate(e);
+    }
+
+    @Override
+    public void changedUpdate(DocumentEvent e) {
+        storeUpdate(e);
+    }
+}

--- a/src/model/CustomJWToken.java
+++ b/src/model/CustomJWToken.java
@@ -278,6 +278,7 @@ public class CustomJWToken extends JWT {
 		try {
 			algorithm = getHeaderJsonNode().get("alg").asText();
 		} catch (Exception e) {
+			Output.outputError("Token getAlgorithm failed");
 		}
 		return algorithm;
 	}

--- a/src/model/JWTInterceptModel.java
+++ b/src/model/JWTInterceptModel.java
@@ -49,14 +49,14 @@ public class JWTInterceptModel {
 		this.jwtJSON = jwtJSON;
 	}
 
-	public void setJWT(String jwt) {
-		this.jwt = jwt;
-
-	}
-
-	public String getJWT() {
-		return this.jwt;
-	}
+//	public void setJWT(String jwt) {
+//		this.jwt = jwt;
+//
+//	}
+//
+//	public String getJWT() {
+//		return this.jwt;
+//	}
 
 	public String getSignature() {
 		return this.signature;

--- a/src/model/Strings.java
+++ b/src/model/Strings.java
@@ -10,6 +10,8 @@ public class Strings {
 	public static final String tokenStateOriginal = "Original";
 	public static final String tokenStateUpdated = "Token updated";
 
+	public static final String createKey = "Create Key";
+	public static final String loadKey = "Load Key";
 	public static final String acceptChanges = "Accept Changes";
 	public static final String recalculateSignature = "Recalculate Signature";
 	public static final String originalToken = "Original Token";
@@ -23,7 +25,8 @@ public class Strings {
 	public static final String verificationInvalidClaim = "Not all Claims accepted";
 	public static final String verificationError = "Invalid Signature / wrong key / claim failed";
 
-	public static final String interceptRecalculationKey = "Secret / Key for Signature recalculation:";
+	public static final String keyTextBoxHeader = "Secret/Key to recalculate signature:";
+	public static final String keyTextBoxToolTip = "Edit or copy/paste key here or use the create or load key buttons.";
 
 	public static final String dontModify = "Do not automatically modify signature";
 	public static final String keepOriginalSignature ="Keep original signature";


### PR DESCRIPTION
Hi ozzi-!

First of all, this is not completely done, but I wanted your input if this is something that you'd want to include upstream (in which case I'll try to re-add all features that are currently not re-implemented).

This started because I was confused by the interface of the interceptor tab and I believed that the extension was not working until I checked what was sent out (and probably also a bug in the handling of the 'none' algorithms). Since I was never certain what the extension changed on the request and wanted visual feedback before the request was sent out, I started to change to InterceptorTab UI to be more "WYSIWYG". The goal was to show any changes (i.e. algorithms, re-signing with new key, ...)  immediately in the JWT text editor interface and also have changes to the text picked up by the UI controls (i.e. manually changing the algorithm in the editor).

* Dedicated buttons for generating keys and re-signing the JWT
* Key/Secret can be auto-generated, loaded from a file (not yet re-added) or copy-pasted in the key text area
* Instant updates of the JWT if algo changes or signature is re-signed (instead of in getMessage())
* JWT from text area is re-evaluated if content changes (text edits, copy/paste) and IM-JSON updated accordingly
* removed 'state machine' in getMessage() and instantly apply changes to IM in event handlers
* use JSON form in IM as only storage representation for the token and update data in view from there (some conversions between json/readable and customjwt could probably be avoided/rewritten, but at the moment it seems to work this way).

Currently missing:

* Load key from file
* CVE 2018-...
* Check UI components for issue due to moved components (add error/issue output box to bottom instead of in logs only)
* probably something else as well ;)

To be discussed:

* should switching to none algorithms also auto-remove the signature? (currently it would be 'switch algo -> empty key -> re-sign')
* should switching the algo remove the key if it is not suitable for this algo?
* I currently did not implement these, since it gives full control over the JWT (e.g. none algo with existing signature). Could be controlled by a checkbox/toggle.
* DelayedDocumentListener is MIT licensed - I referenced the original source + license but I'm not sure if this is the correct way to handle it (src/app/helpers/DelayedDocumentListener.java)


