### PR TITLE
Add Ms Office365 JWT, fixes hex key conversion error.

### DIFF
--- a/src/app/algorithm/AlgorithmWrapper.java
+++ b/src/app/algorithm/AlgorithmWrapper.java
@@ -40,6 +40,40 @@ public enum AlgorithmWrapper {
 		return algorithmName;
 	}
 
+	private Algorithm algorithm(byte[] key) {
+		switch (this) {
+			// HMAC with SHA-XXX
+			case HS256:
+				return Algorithm.HMAC256(key);
+			case HS384:
+				return Algorithm.HMAC384(key);
+			case HS512:
+				return Algorithm.HMAC512(key);
+
+			// ECDSA with curve
+			case ES256:
+				return Algorithm.ECDSA256(new ECDSAKeyProviderImpl(new String(key)));
+			case ES256K:
+				return Algorithm.ECDSA256K(new ECDSAKeyProviderImpl(new String(key)));
+			case ES384:
+				return Algorithm.ECDSA384(new ECDSAKeyProviderImpl(new String(key)));
+			case ES512:
+				return Algorithm.ECDSA512(new ECDSAKeyProviderImpl(new String(key)));
+
+			// RSASSA-PKCS1-v1_5 with SHA-XXX
+			case RS256:
+				return Algorithm.RSA256(new RSAKeyProviderImpl(new String(key)));
+			case RS384:
+				return Algorithm.RSA384(new RSAKeyProviderImpl(new String(key)));
+			case RS512:
+				return Algorithm.RSA512(new RSAKeyProviderImpl(new String(key)));
+
+			case NONE:
+			default:
+				throw new AlgorithmMismatchException("Unsupported algorithm '" + algorithmName + "'");
+		}
+	}
+
 	private Algorithm algorithm(String key) {
 		switch (this) {
 			// HMAC with SHA-XXX
@@ -73,7 +107,6 @@ public enum AlgorithmWrapper {
 				throw new AlgorithmMismatchException("Unsupported algorithm '" + algorithmName + "'");
 		}
 	}
-
 	public static Algorithm getVerifierAlgorithm(String algo, String key) {
 		return withName(algo).algorithm(key);
 	}
@@ -82,6 +115,9 @@ public enum AlgorithmWrapper {
 		return withName(algo).algorithm(key);
 	}
 
+	public static Algorithm getSignerAlgorithm(String algo, byte[] key) {
+		return withName(algo).algorithm(key);
+	}
 	public static AlgorithmWrapper withName(String algorithm) {
 		return Stream.of(AlgorithmWrapper.values())
 				.filter(supportedAlgorithm -> algorithm.equals(supportedAlgorithm.algorithmName()))

--- a/src/app/controllers/JWTInterceptTabController.java
+++ b/src/app/controllers/JWTInterceptTabController.java
@@ -6,6 +6,9 @@ import java.awt.Frame;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.List;
@@ -167,9 +170,45 @@ public class JWTInterceptTabController implements IMessageEditorTab {
         String key = getKeyWithHexDetection(jwtIM);
         Output.output("Signing with manually entered key '" + key + "' (" + jwtIM.getJWTKey() + ")");
         CustomJWToken token = ReadableTokenFormat.getTokenFromView(jwtST);
-        Algorithm algo = AlgorithmWrapper.getSignerAlgorithm(token.getAlgorithm(), key);
-        token.calculateAndSetSignature(algo);
-        reflectChangeToView(token, false);
+        String tokenalgo = token.getAlgorithm();
+        boolean o365 = false;
+
+        if ( Config.o365Support && token.getHeaderJson().contains(  "\"ctx\":") && tokenalgo.contains("HS256")) {
+          String label = "AzureAD-SecureConversation";
+          String ctx = token.getHeaderJsonNode().get("ctx").asText();
+          byte[] ctxbytes = Base64.getDecoder().decode(ctx);
+
+          //if token was created with kdf version 2
+          if (token.getHeaderJson().contains("\"kdf_ver\": 2")) {
+            byte[] fullctxbytes = new byte[24 + token.getPayloadJson().replaceAll(" ","").replaceAll("\n","").length()];
+            System.arraycopy(ctxbytes,0,fullctxbytes,0,24);
+            System.arraycopy(token.getPayloadJson().replaceAll(" ","")
+                            .replaceAll("\n","").getBytes(StandardCharsets.ISO_8859_1),0,fullctxbytes,
+                    24,token.getPayloadJson().replaceAll(" ","").replaceAll("\n","").length());
+            byte[] keydata = key.getBytes(StandardCharsets.ISO_8859_1);
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            ctxbytes =  digest.digest(fullctxbytes);
+          }
+
+          byte[] newarr = new byte[4 + label.getBytes("UTF-8").length + 1 + ctxbytes.length + 4];
+          System.arraycopy(new byte[]{(byte) 0x00, 0x00, 0x00, 0x01}, 0, newarr,0,4 );
+          System.arraycopy(label.getBytes("UTF-8"),0,newarr,4,26);
+          System.arraycopy(new byte[]{(byte) 0x00},0,newarr,30,1);
+          System.arraycopy(ctxbytes,0,newarr,31,ctxbytes.length);
+          System.arraycopy(new byte[]{(byte) 0x00, 0x00, 0x01, 0x00}, 0, newarr,newarr.length-4,4 );
+          byte[] keydata = key.getBytes(StandardCharsets.ISO_8859_1);
+          byte[] hmacSha256 = KeyHelper.calcHmacSha256(keydata, newarr);
+
+          Algorithm algo = AlgorithmWrapper.getSignerAlgorithm(token.getAlgorithm(), hmacSha256);
+          Output.output("Signing with MS O365 derived key: " + Hex.encodeHexString(hmacSha256));
+          token.calculateAndSetSignature(algo);
+          reflectChangeToView(token, false);
+        }
+        else {
+          Algorithm algo = AlgorithmWrapper.getSignerAlgorithm(token.getAlgorithm(), key);
+          token.calculateAndSetSignature(algo);
+          reflectChangeToView(token, false);
+        }
         clearError();
       }
     } catch (Exception e) {
@@ -185,7 +224,8 @@ public class JWTInterceptTabController implements IMessageEditorTab {
     if (key.startsWith(HEX_MARKER)) {
       try {
         key = key.substring(2);
-        key = new String(Hex.decodeHex(key));
+        byte[] bytes = Hex.decodeHex(key);
+        key = new String(bytes, StandardCharsets.ISO_8859_1);
       } catch (Exception e) {
         key = jwtIM.getJWTKey();
       }

--- a/src/app/helpers/Config.java
+++ b/src/app/helpers/Config.java
@@ -23,6 +23,7 @@ public class Config {
   public static String highlightColor = "blue";
   public static String interceptComment = "Contains a JWT";
   public static boolean resetEditor = true;
+  public static boolean o365Support = true;
   public static String configName = "config.json";
   public static String configFolderName = ".JWT4B";
   public static String configPath =
@@ -126,6 +127,8 @@ public class Config {
 
       resetEditor = configJO.getBoolean("resetEditor", true);
 
+      o365Support = configJO.getBoolean("o365Support", true);
+
       highlightColor = configJO.get("highlightColor").asString();
       // 	red, orange, yellow, green, cyan, blue, pink, magenta, gray,or a null String to clear any existing highlight.
       ArrayList<String> allowedColors = new ArrayList<>(
@@ -161,6 +164,7 @@ public class Config {
     }
 
     configJO.add("resetEditor", true);
+    configJO.add("o365Support", true);
     configJO.add("highlightColor", highlightColor);
     configJO.add("interceptComment", interceptComment);
     configJO.add("jwtKeywords", jwtKeywordsJA);

--- a/src/app/helpers/KeyHelper.java
+++ b/src/app/helpers/KeyHelper.java
@@ -20,6 +20,9 @@ import org.apache.commons.lang.RandomStringUtils;
 
 import app.algorithm.AlgorithmType;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
 public class KeyHelper {
     private static final String[] KEY_BEGIN_MARKERS = new String[]{"-----BEGIN PUBLIC KEY-----",
           "-----BEGIN CERTIFICATE-----"};
@@ -117,4 +120,18 @@ public class KeyHelper {
             generatePrivateKeyFromString(key, algorithm) :
             generatePublicKeyFromString(key, algorithm);
   }
+
+  public static byte[] calcHmacSha256(byte[] secretKey, byte[] message) {
+    byte[] hmacSha256 = null;
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey, "HmacSHA256");
+      mac.init(secretKeySpec);
+      hmacSha256 = mac.doFinal(message);
+    } catch (Exception e) {
+      Output.outputError("Exception during random key generation & signing: " + e.getMessage());
+    }
+    return hmacSha256;
+  }
 }
+


### PR DESCRIPTION
1. Fix error with converting from hex string in case of  hex key contains some non-ascii bytes. 
When hex string contains some non-ascii bytes expression ` key = new String(Hex.decodeHex(key));` gives incorrect transform. so key will be is wrong. The correct expression will be: `key = new String(Hex.decodeHex(key),StandardCharsets.ISO_8859_1);`

2. Add Microsoft Office365 JWTs support. 
When windows logins to Microsoft services AADCore dll uses **ctx** field in JWT header to derive signing keys (in case of kdf_ver:1) and **ctx+payload** (in case of kfd_ver:2). Kdf_ver 2 (key deviation function) is used in windows ver >= 10.19043. 
So with this commits JWT4B can derive signing keys  and sign Office365 JWT with supplied session keys in hex (with 0x prefix). U can read more about session keys and MS JWT in DirkJanm researches (https://dirkjanm.io/abusing-azure-ad-sso-with-the-primary-refresh-token/)